### PR TITLE
why

### DIFF
--- a/script.js
+++ b/script.js
@@ -15,29 +15,29 @@ function jsonToXml(json) {
 
 // Fetch JSON data from the API
 fetch('https://jsonplaceholder.typicode.com/posts')
-    .then(response => response.json())
-    .then(jsonData => {
-        const xmlData = jsonToXml(jsonData);
+  .then(response => response.json())
+  .then(jsonData => {
+    const xmlData = jsonToXml(jsonData);
 
-        // Fetch XSLT file and transform XML to HTML
-        return fetch('style.xsl')
-            .then(response => response.text())
-            .then(xsltData => {
-                // Function to transform XML with XSLT
-                function transformXml(xmlString, xsltString) {
-                    
-                    const parser = new DOMParser();
-                    const xml = parser.parseFromString(xmlString, 'application/xml');
-                    const xslt = parser.parseFromString(xsltString, 'application/xml');
-                    const xsltProcessor = new XSLTProcessor();
-                    xsltProcessor.importStylesheet(xslt);
-                    const resultDocument = xsltProcessor.transformToFragment(xml, document);
-                    console.log(xmlString);
-                    return resultDocument;
-                }
+    // Fetch XSLT file and transform XML to HTML
+    return fetch('style.xsl')
+      .then(response => response.text())
+      .then(xsltData => {
+        // Function to transform XML with XSLT
+        function transformXml(xmlString, xsltString) {
 
-                // Display the transformed HTML in the tableContainer
-                document.getElementById('tableContainer').appendChild(transformXml(xmlData, xsltData));
-            });
-    })
-    .catch(error => console.error('Error:', error));
+          const parser = new DOMParser();
+          const xml = parser.parseFromString(xmlString, 'application/xml');
+          const xslt = parser.parseFromString(xsltString, 'application/xml');
+          const xsltProcessor = new XSLTProcessor();
+          xsltProcessor.importStylesheet(xslt);
+          const resultDocument = xsltProcessor.transformToFragment(xml, document);
+          console.log(xmlString);
+          return resultDocument;
+        }
+
+        const doc = transformXml(xmlData, xsltData);
+        document.getElementById('tableContainer').innerHTML = new XMLSerializer().serializeToString(doc);
+      });
+  })
+  .catch(error => console.error('Error:', error));


### PR DESCRIPTION
Also so könnte man das machen. Es fühlt sich aber verdammt falsch an.
Ich glaube ich frage nochmal bei Röthig nach, ob er das wirklich will.

Bei Niklas Projekt hab ich das `xsl:output` nicht gefunden, vielleicht ist das wirklich besser es dann wegzulassen.
Der browser macht ja eigentlich das was er soll, er produziert XML kein HTML.